### PR TITLE
Remove the mfe and discovery plugins as hard dependencies

### DIFF
--- a/tutorecommerce/patches/local-docker-compose-services
+++ b/tutorecommerce/patches/local-docker-compose-services
@@ -6,7 +6,7 @@ ecommerce:
   volumes:
     - ../plugins/ecommerce/apps/ecommerce/settings:/openedx/ecommerce/ecommerce/settings/tutor:ro
   depends_on:
-    - discovery
+    {% if RUN_DISCOVERY %}- discovery{% endif %}
     {% if RUN_MYSQL %}- mysql{% endif %}
     {% if RUN_LMS %}- lms{% endif %}
 

--- a/tutorecommerce/patches/mfe-env-development
+++ b/tutorecommerce/patches/mfe-env-development
@@ -1,2 +1,4 @@
 ECOMMERCE_BASE_URL='http://{{ ECOMMERCE_HOST }}:8130'
+{% if MFE_HOST is defined %}
 ORDER_HISTORY_URL='http://{{ MFE_HOST }}:{{ ECOMMERCE_PAYMENT_MFE_APP['port'] }}/{{ ECOMMERCE_PAYMENT_MFE_APP['name'] }}/orders'
+{% endif %}

--- a/tutorecommerce/patches/openedx-lms-production-settings
+++ b/tutorecommerce/patches/openedx-lms-production-settings
@@ -1,3 +1,5 @@
 ECOMMERCE_PUBLIC_URL_ROOT = "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ ECOMMERCE_HOST }}"
 ECOMMERCE_API_URL = ECOMMERCE_PUBLIC_URL_ROOT + "/api/v2"
-ORDER_HISTORY_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ MFE_HOST }}/ecommerce/orders"
+{% if MFE_HOST is defined %}
+ORDER_HISTORY_MICROFRONTEND_URL = "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ MFE_HOST | default('mfe')}}/ecommerce/orders"
+{% endif %}

--- a/tutorecommerce/templates/ecommerce/apps/ecommerce/settings/development.py
+++ b/tutorecommerce/templates/ecommerce/apps/ecommerce/settings/development.py
@@ -2,12 +2,14 @@ from ..devstack import *
 
 {% include "ecommerce/apps/ecommerce/settings/partials/common.py" %}
 
+{% if MFE_HOST is defined %}
 CORS_ORIGIN_WHITELIST = list(CORS_ORIGIN_WHITELIST) + [
     "http://{{ MFE_HOST }}:{{ ECOMMERCE_MFE_APP['port'] }}",
 ]
 CSRF_TRUSTED_ORIGINS = [
     "http://{{ MFE_HOST }}:{{ ECOMMERCE_MFE_APP['port'] }}",
 ]
+{% endif %}
 
 SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT = "http://{{ LMS_HOST }}:8000"
 

--- a/tutorecommerce/templates/ecommerce/apps/ecommerce/settings/production.py
+++ b/tutorecommerce/templates/ecommerce/apps/ecommerce/settings/production.py
@@ -2,12 +2,14 @@ from ..production import *
 
 {% include "ecommerce/apps/ecommerce/settings/partials/common.py" %}
 
+{% if MFE_HOST is defined %}
 CORS_ORIGIN_WHITELIST = list(CORS_ORIGIN_WHITELIST) + [
     "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ MFE_HOST }}",
 ]
 CSRF_TRUSTED_ORIGINS = [
     "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ MFE_HOST }}",
 ]
+{% endif %}
 
 SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT = "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}"
 

--- a/tutorecommerce/templates/ecommerce/hooks/ecommerce/init
+++ b/tutorecommerce/templates/ecommerce/hooks/ecommerce/init
@@ -15,9 +15,11 @@
   --backend-service-client-id="{{ ECOMMERCE_OAUTH2_KEY_DEV }}" \
   --backend-service-client-secret="{{ ECOMMERCE_OAUTH2_SECRET }}" \
   --from-email {{ CONTACT_EMAIL }} \
-  --discovery_api_url=http://{{ DISCOVERY_HOST }}:8381/api/v1/ \
+  --discovery_api_url=http://{{ DISCOVERY_HOST | default('discovery')}}:8381/api/v1/ \
+  {% if MFE_HOST is defined %}
   --enable-microfrontend-for-basket-page=true \
   --payment-microfrontend-url="http://{{ MFE_HOST }}:{{ ECOMMERCE_PAYMENT_MFE_APP['port'] }}/{{ ECOMMERCE_PAYMENT_MFE_APP['name'] }}"
+  {% endif %}
 
 # Production site
 ./manage.py create_or_update_site \
@@ -35,6 +37,11 @@
   --backend-service-client-id="{{ ECOMMERCE_OAUTH2_KEY }}" \
   --backend-service-client-secret="{{ ECOMMERCE_OAUTH2_SECRET }}" \
   --from-email {{ CONTACT_EMAIL }} \
-  --discovery_api_url={% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ DISCOVERY_HOST }}/api/v1/ \
+  --discovery_api_url={% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ DISCOVERY_HOST | default('discovery')}}/api/v1/ \
+  {% if MFE_HOST is defined %}
   --enable-microfrontend-for-basket-page=true \
   --payment-microfrontend-url="{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ MFE_HOST }}/{{ ECOMMERCE_PAYMENT_MFE_APP['name'] }}"
+  {% endif %}
+
+./manage.py waffle_flag disable_microfrontend_for_basket_page --everyone
+./manage.py waffle_flag enable_client_side_checkout --deactivate

--- a/tutorecommerce/templates/ecommerce/hooks/lms/init
+++ b/tutorecommerce/templates/ecommerce/hooks/lms/init
@@ -51,3 +51,4 @@
 
   # Enable order bistory microfrontend
   (./manage.py lms waffle_switch --list | grep order_history.redirect_to_microfrontend) || ./manage.py lms waffle_switch --create order_history.redirect_to_microfrontend on
+  ./manage.py lms configure_commerce


### PR DESCRIPTION
## Description
The tutor ecommerce plugin includes as dependencies two additional tutor plugins: `mfe` and `discovery`.

eCommerce performs some API calls to the Discovery service to complement some course information, but can still offer all its functionality even if it can't connect to the Discovery Service.

It also relies on several MFE applications to perform its normal flow. It's possible to modify the value of a couple of waffle flags to get access to the old checkout page views.

This PR modifies several hooks that initialize the ecommerce service:

- Only setup the settings that relies on `mfe` and `discovery` only if those plugins are installed
- Activate `disable_microfrontend_for_basket_page` waffle flag
- Deactivate `enable_client_side_checkout` waffle flag
- Configure the `commerce` service in the LMS.