### PR TITLE
Add a dev image with extra utils

### DIFF
--- a/tutorecommerce/patches/local-docker-compose-dev-services
+++ b/tutorecommerce/patches/local-docker-compose-dev-services
@@ -1,4 +1,5 @@
 ecommerce:
+  image: {{ ECOMMERCE_DOCKER_IMAGE_DEV }}
   environment:
     DJANGO_SETTINGS_MODULE: ecommerce.settings.tutor.development
   command: ./manage.py runserver 0.0.0.0:8130

--- a/tutorecommerce/plugin.py
+++ b/tutorecommerce/plugin.py
@@ -87,6 +87,7 @@ config = {
 hooks = {
     "build-image": {
         "ecommerce": "{{ ECOMMERCE_DOCKER_IMAGE }}",
+        "ecommerce-dev": "{{ ECOMMERCE_DOCKER_IMAGE_DEV }}",
         "ecommerce-worker": "{{ ECOMMERCE_WORKER_DOCKER_IMAGE }}",
     },
     "remote-image": {

--- a/tutorecommerce/templates/ecommerce/build/ecommerce-dev/Dockerfile
+++ b/tutorecommerce/templates/ecommerce/build/ecommerce-dev/Dockerfile
@@ -1,0 +1,17 @@
+FROM {{ ECOMMERCE_DOCKER_IMAGE }} as base
+MAINTAINER eduNEXT <contact@edunext.co>
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Install useful system requirements
+RUN apt update && \
+    apt install -y vim iputils-ping dnsutils \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install dev python requirements
+RUN pip install ipdb==0.13.4 ipython==7.27.0
+
+{{ patch("ecommerce-dev-dockerfile-post-python-requirements") }}
+
+######## Development image
+FROM base as dev


### PR DESCRIPTION

## Description
Add a new image to be used on the dev services. It includes extra tools and a `ecommerce-dev-dockerfile-post-python-requirements` patch to install packages in editable mode (mainly `ecommerce-extensions`)