### PR TITLE
feat: remove creation of site not presented

### DIFF
--- a/tutorecommerce/templates/ecommerce/hooks/ecommerce/init
+++ b/tutorecommerce/templates/ecommerce/hooks/ecommerce/init
@@ -1,6 +1,7 @@
 ./manage.py migrate --noinput
 ./manage.py oscar_populate_countries --initial-only
 
+{% if not ECOMMERCE_DB_PREVIOUS_SITES %}
 ./manage.py create_or_update_site \
   --site-id=1 \
   --site-domain={{ ECOMMERCE_HOST }}:8130 \
@@ -46,6 +47,6 @@
   --enable-microfrontend-for-basket-page=true \
   --payment-microfrontend-url="{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ MFE_HOST }}/{{ ECOMMERCE_PAYMENT_MFE_APP['name'] }}"
   {% endif %}
-
+{% endif %}
 ./manage.py waffle_flag disable_microfrontend_for_basket_page --everyone
 ./manage.py waffle_flag enable_client_side_checkout --deactivate


### PR DESCRIPTION
# Description
The idea is to use in `config.yml` the `ECOMMERCE_DB_PREVIOUS_SITES` option in true to avoid conflict-creating sites assuming is a new or empty DB.